### PR TITLE
Feature/Selective mocking

### DIFF
--- a/lib/src/adapters/dio_adapter.dart
+++ b/lib/src/adapters/dio_adapter.dart
@@ -17,10 +17,17 @@ class DioAdapter with Recording, RequestHandling implements HttpClientAdapter {
   @override
   final HttpRequestMatcher matcher;
 
+  @override
+  final bool printLogs;
+
+  @override
+  final bool failOnMissingMock = true;
+
   /// Constructs a [DioAdapter] and configures the passed [Dio] instance.
   DioAdapter({
     required this.dio,
     this.matcher = const FullHttpRequestMatcher(),
+    this.printLogs = false,
   }) {
     dio.httpClientAdapter = this;
   }
@@ -40,7 +47,7 @@ class DioAdapter with Recording, RequestHandling implements HttpClientAdapter {
     }
 
     await setDefaultRequestHeaders(dio, requestOptions);
-    final response = await mockResponse(requestOptions);
+    final response = await mockResponse(requestOptions) as MockResponse;
 
     // Waits for defined duration.
     if (response.delay != null) await Future.delayed(response.delay!);

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -11,10 +11,18 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
   @override
   final HttpRequestMatcher matcher;
 
+  @override
+  final bool printLogs;
+
+  @override
+  final bool failOnMissingMock;
+
   /// Constructs a [DioInterceptor] and configures the passed [Dio] instance.
   DioInterceptor({
     required this.dio,
     this.matcher = const FullHttpRequestMatcher(),
+    this.printLogs = false,
+    this.failOnMissingMock = false,
   }) {
     dio.interceptors.add(this);
   }
@@ -25,6 +33,11 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
   void onRequest(requestOptions, requestInterceptorHandler) async {
     await setDefaultRequestHeaders(dio, requestOptions);
     final response = await mockResponse(requestOptions);
+
+    if (response == null) {
+      requestInterceptorHandler.next(requestOptions);
+      return;
+    }
 
     // Reject the response if type is MockDioException.
     if (isMockDioException(response)) {

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -22,7 +22,7 @@ class DioInterceptor extends Interceptor with Recording, RequestHandling {
     required this.dio,
     this.matcher = const FullHttpRequestMatcher(),
     this.printLogs = false,
-    this.failOnMissingMock = false,
+    this.failOnMissingMock = true,
   }) {
     dio.interceptors.add(this);
   }

--- a/lib/src/mixins/recording.dart
+++ b/lib/src/mixins/recording.dart
@@ -5,6 +5,10 @@ import 'package:http_mock_adapter/src/types.dart';
 
 /// An ability that lets a construct to record a [RequestMatcher] history.
 mixin Recording {
+  bool get printLogs;
+
+  bool get failOnMissingMock;
+
   HttpRequestMatcher get matcher;
 
   /// The index of request invocations.
@@ -29,8 +33,22 @@ mixin Recording {
 
         // Fail when a mocked route is not found for the request.
         if (_invocationIndex == null || _invocationIndex! < 0) {
-          throw AssertionError(
-            'Could not find mocked route matching request for ${requestOptions.signature}',
+          if (failOnMissingMock) {
+            throw AssertionError(
+              'Could not find mocked route matching request for ${requestOptions.signature}',
+            );
+          }
+          if (printLogs) {
+            print(
+              'Not matched request: ${requestOptions.method} ${requestOptions.uri}',
+            );
+          }
+          return Future.value(null);
+        }
+
+        if (printLogs) {
+          print(
+            'Matched request: ${requestOptions.method} ${requestOptions.uri}',
           );
         }
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -9,7 +9,7 @@ typedef MockServerCallback = void Function(MockServer server);
 
 /// Type for [Recording]'s [ResponseBody], which takes [RequestOptions] as a parameter
 /// and compares its signature to saved [Request]'s signature and chooses right response.
-typedef MockResponseBodyCallback = Future<MockResponse> Function(
+typedef MockResponseBodyCallback = Future<MockResponse?> Function(
   RequestOptions options,
 );
 

--- a/test/interceptors/dio_interceptor_test.dart
+++ b/test/interceptors/dio_interceptor_test.dart
@@ -1,0 +1,43 @@
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Dio dio;
+  late DioInterceptor dioInterceptor1;
+  late DioInterceptor dioInterceptor2;
+
+  setUp(() {
+    dio = Dio();
+  });
+
+  group('DioInterceptor', () {
+    test('if failOnMissingMock is false do not fail on missing mock', () async {
+      dioInterceptor1 = DioInterceptor(dio: dio, failOnMissingMock: false);
+      dioInterceptor2 = DioInterceptor(dio: dio, failOnMissingMock: false);
+
+      dio.interceptors.addAll([dioInterceptor1, dioInterceptor2]);
+
+      dioInterceptor1.onGet(
+        '/interceptor-1-route',
+        (server) => server.reply(
+          200,
+          {'message': 'Success from interceptor 1'},
+        ),
+      );
+      dioInterceptor1.onGet(
+        '/interceptor-2-route',
+        (server) => server.reply(
+          200,
+          {'message': 'Success from interceptor 2'},
+        ),
+      );
+
+      final int1Response = await dio.get('/interceptor-1-route');
+      expect(int1Response.data, {'message': 'Success from interceptor 1'});
+
+      final int2Response = await dio.get('/interceptor-2-route');
+      expect(int2Response.data, {'message': 'Success from interceptor 2'});
+    });
+  });
+}


### PR DESCRIPTION
This PR is a proposal for issue #136. 

This package has two ways of mocking for Dio: 
- `DioInterceptor`
- `DioAdapter`

It is my understanding that selective mocking only works for the first one as the latter one completely exchanges the `HttpClientAdapter` of Dio. 

My proposed solution is to add a boolean `failOnMissingMock`, which is by default `true` for backwards compatibility. If set to `false` we do not throw an exception anymore when a mock is not matched, but instead send back a `Future.value(null)`. This way we can detect the mismatch in the `DioInterceptor` and let `Dio` call the next interceptor. 

Also, I added an option to print basic logs which are by default turned off.

@LukaGiorgadze what do you think?