### PR TITLE
chore/downgrade-collection-to-1.17.1

### DIFF
--- a/lib/src/logger/logger.dart
+++ b/lib/src/logger/logger.dart
@@ -1,6 +1,6 @@
 import 'package:logger/logger.dart';
 
-getLogger(bool printLogs) {
+Logger getLogger(bool printLogs) {
   return Logger(
     level: printLogs ? Level.debug : Level.off,
     printer: PrettyPrinter(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '^3.0.0'
 
 dependencies:
-  collection: ^1.18.0
+  collection: ^1.17.1
   dio: ^5.3.2
   http_parser: ^4.0.2
   logger: ^2.0.1


### PR DESCRIPTION
Downgrade `collection` to 1.17.1 due to compatibility reasons.

Minor: added return type for `getLogger`.